### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+For bugs related to R, [`reprex`](https://reprex.tidyverse.org/) is the easiest way to ensure a reproducible error and documented environment. 
+
+Steps to reproduce the behavior:
+1. run this code / push this button '...'
+2. open '....'
+3. look at '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+
+- Operating System
+- Version of software, libraries used
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/component.md
+++ b/.github/ISSUE_TEMPLATE/component.md
@@ -1,0 +1,19 @@
+---
+name: Component
+about: Template for the four highest level tasks defined in the CCMMF workplan
+title: 'Component: n [Title]'
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+
+**Milestones and Deliverables**
+
+- [ ] 1.1
+- [ ] 1.2
+
+**Dependencies**
+
+**Additional Information**

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,19 @@
+---
+name: Epic
+about: Epics are scopes of work consisting of multiple issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Epic: [Title]
+
+**Description**
+
+**tasks**
+
+* [ ] description and link to task #0
+* [ ] etc
+
+**additional information**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/milestone.md
+++ b/.github/ISSUE_TEMPLATE/milestone.md
@@ -1,0 +1,17 @@
+---
+name: Milestone
+about: Milestones are subcomponents of components
+title: Milestone n.m [Title]
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+
+**Epics and Issues**
+
+
+**Dependencies**
+
+**Additional Information**

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,14 @@
+---
+name: Task
+about: Actionable items within an epic, taking a few hours to a week
+title: "[Task] Title"
+labels: ''
+assignees: ''
+
+---
+
+**steps**
+
+- [ ] boil water
+- [ ] add pasta
+- [ ] ...


### PR DESCRIPTION
I am renaming what we currently call "tasks" --> components and "sub-tasks" --> milestones, thus:

- Components: currently 'tasks' 1-4
- Milestones: currently 'sub-tasks' 1.1, 1.2, ...
- Epics: take longer than a sprint, have many tasks
- Tasks: should take a few hours to a week

Ironically, 'tasks' are now the smallest item in the hierarchy.